### PR TITLE
Increased loadUrlTimeoutValue to allow emulator to run

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -16,6 +16,7 @@
   <preference name="SplashScreen" value="screen"/>
   <preference name="SplashMaintainAspectRatio" value="true"/>
   <preference name="orientation" value="portrait"/>
+  <preference name="loadUrlTimeoutValue" value="140000" />
   <platform name="android">
     <preference name="SplashScreenDelay" value="10000"/>
     <preference name="AutoHideSplashScreen" value="true"/>


### PR DESCRIPTION
This allows the Android emulator to run the project. Default is 20000 which is 20 seconds. PR makes it 140000, 140 seconds, which seems really long and it is. But the Android emulator is really slow (even on a very decent laptop).

Not sure if it's possible to increase it just for debugging. Or just maybe put this in the readme for emulator purposes just like the command `ionic emulate android`.