### PR TITLE
fix crash  when use appconfig.example.json

### DIFF
--- a/appconfig.example.json
+++ b/appconfig.example.json
@@ -1,5 +1,6 @@
 {
     "DEBUG": true,
     "MINIFY": false,
-    "TESTNET": true
+    "TESTNET": true,
+    "GA_TRACKING_ID": "UA-66176065-21"
 }


### PR DESCRIPTION
When is not set "GA_TRACKING_ID",There was a crash
```

        0   CoreFoundation                      0x0000000109b07b0b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x000000010ee26141 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000109b77134 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x0000000109a8e840 ___forwarding___ + 1024
	4   CoreFoundation                      0x0000000109a8e3b8 _CF_forwarding_prep_0 + 120
	5   BlockTrail Wallet                   0x0000000109400263 -[GAI trackerWithName:trackingId:] + 46
	6   BlockTrail Wallet                   0x0000000109327b66 __47-[UniversalAnalyticsPlugin startTrackerWithId:]_block_invoke + 230
	7   libdispatch.dylib                   0x000000010f6b74a6 _dispatch_call_block_and_release + 12
	8   libdispatch.dylib                   0x000000010f6e005c _dispatch_client_callout + 8
	9   libdispatch.dylib                   0x000000010f6bfdcd _dispatch_queue_override_invoke + 1321
	10  libdispatch.dylib                   0x000000010f6c1ec4 _dispatch_root_queue_drain + 634
	11  libdispatch.dylib                   0x000000010f6c1bef _dispatch_worker_thread3 + 123
	12  libsystem_pthread.dylib             0x000000010fa77712 _pthread_wqthread + 1299
	13  libsystem_pthread.dylib             0x000000010fa771ed start_wqthread + 13

```
In the example set up GA_TRACKING_ID