### PR TITLE
fix chinese line height issue in send screen

### DIFF
--- a/src/templates/send/send.input-screen.html
+++ b/src/templates/send/send.input-screen.html
@@ -21,7 +21,7 @@
                         <canvas-display
                                 text="$translate.instant('AVAILABLE_BALANCE')"
                                 width="100%"
-                                height="17"
+                                height="19"
                                 font="17px 'Helvetica', 'Roboto', 'Open Sans', sans-serif "
                                 text-baseline="bottom"
                                 color="#FFFFFF">


### PR DESCRIPTION
Please review and merge.

I checked the mobile app for other line height cut-offs than this one /wrt chinese, but couldn't find any more.