### PR TITLE
Bump SDK to v3.5.3, bech32 support

### DIFF
--- a/src/js/modules/core/services/wallet/wallet.service.js
+++ b/src/js/modules/core/services/wallet/wallet.service.js
@@ -1114,24 +1114,9 @@
     Wallet.prototype.validateAddress = function(address) {
         var self = this;
 
-        return self._$q.when(address)
-            .then(function(address) {
-                var addr, err;
-
-                try {
-                    addr = self._bitcoinJS.address.fromBase58Check(address);
-                    if (addr.version !== self._sdkWallet.sdk.network.pubKeyHash && addr.version !== self._sdkWallet.sdk.network.scriptHash) {
-                        err = new blocktrail.InvalidAddressError("Invalid network");
-                    }
-                } catch (_err) {
-                    err = _err;
-                }
-
-                if (!addr || err) {
-                    throw new blocktrail.InvalidAddressError("Invalid address [" + address + "]" + (err ? " (" + err.message + ")" : ""));
-                }
-
-                return address;
+        return self._$q.when(self._sdkWallet)
+            .then(function(wallet) {
+                return wallet.decodeAddress(address).address
             });
     };
 


### PR DESCRIPTION
makes validateAddress depend on SDK