### PR TITLE
Don't display 0 fee, add fee to initial scope

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -484,7 +484,7 @@ angular.module('blocktrail.wallet').config(
                 url: "/pin",
                 cache: false,
                 data: {
-                    clearHistory: false,
+                    clearHistory: true,
                     excludeFromHistory: true
                 },
                 templateUrl: "js/modules/wallet/controllers/open-wallet-pin/open-wallet-pin.tpl.html",

--- a/src/js/modules/wallet/controllers/send/send.ctrl.js
+++ b/src/js/modules/wallet/controllers/send/send.ctrl.js
@@ -58,6 +58,8 @@
 
         $scope.pay = {};
         $scope.useZeroConf = true;
+
+        $scope.fee = null;
         $scope.fees = {
             optimal: null,
             lowPriority: null,
@@ -229,7 +231,7 @@
             $scope.fees.lowPriority = null;
             $scope.fees.optimal = null;
             $scope.fees.minRelayFee = null;
-            $scope.displayFee = false;
+            $scope.appControl.displayFee = false;
             $scope.prioboost.possible = null;
             $scope.prioboost.estSize = null;
             $scope.prioboost.zeroConf = null;
@@ -329,7 +331,7 @@
                         $scope.fees.lowPriority = lowPriorityFee;
                         $scope.fees.optimal = optimalFee;
                         $scope.fees.minRelayFee = minRelayFee;
-                        $scope.displayFee = true;
+                        $scope.appControl.displayFee = true;
 
                         return $scope.updateFee();
                     }, function (e) {

--- a/src/js/modules/wallet/controllers/send/send.tpl.html
+++ b/src/js/modules/wallet/controllers/send/send.tpl.html
@@ -170,7 +170,8 @@
                         <span class="fee-choice-selected-edit" ui-sref="app.wallet.send.fee-choice">
                             <i class="icon icon-edit"></i>
                         </span>
-                        <span class="fee-choice-selected-fee"  ng-show="appControl.displayFee && sendInput.btcValue + sendInput.fiatValue > 0">
+                        <span class="fee-choice-selected-fee"
+                              ng-show="appControl.displayFee && sendInput.btcValue + sendInput.fiatValue > 0">
                             {{ fee | satoshiToCoin : walletData.networkType : 8 : false : 'hide' }}
                         </span>
                     </div>


### PR DESCRIPTION
Do not display fee if coin-selection fails because of insufficient wallet balance.