### PR TITLE
Show balance and transactions only when loading wallet is done

### DIFF
--- a/src/js/modules/wallet/controllers/wallet-summary/wallet-summary.tpl.html
+++ b/src/js/modules/wallet/controllers/wallet-summary/wallet-summary.tpl.html
@@ -12,7 +12,7 @@
                 <i class="icon ion-person" ng-if="!settingsData.profilePic"></i>
             </div>
         </div>
-        <div class="wallet-info-description">
+        <div class="wallet-info-description" ng-show="!isLoading">
             <h1 ng-bind-html="((walletData.balance + walletData.uncBalance) | satoshiToCoin : walletData.networkType : localSettingsData.btcPrecision : true : 'short')"></h1>
             <p>{{ (walletData.balance + walletData.uncBalance) | satoshiToCurrency : settingsData.localCurrency : bitcoinPrices }}</p>
         </div>
@@ -31,7 +31,7 @@
             <ion-spinner></ion-spinner>
         </div>
 
-        <ion-list class="transactions-list">
+        <ion-list class="transactions-list" ng-show="!isLoading">
             <div ng-if="buyBtcPendingOrders.length > 0">
                 <!-- Show header -->
                 <div>


### PR DESCRIPTION
Resolved a split-second display of wrong fiat amount when switching to other coin.
Solution is not to show the coin amount and fiat amount until `isLoading` is set to `false`.
Applied it to the transaction list as well, but it may not be necessary there.